### PR TITLE
Save scum for shinies at dungeons

### DIFF
--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -584,7 +584,10 @@
 		}
 
 		reportDebug() {
-			console.log("Clearing", this.dungeonName, this.clearGoal, "times total. Done", this.taskEntries, "/", this.taskClears, "so far.", this.remainingEntries, "left.");
+			console.log("Clearing", this.dungeonName,
+					this.clearGoal, "times total.",
+					"Done", this.taskEntries, "/", this.taskClears, "so far.",
+					this.remainingEntries, "left.");
 		}
 
 		static fromData(data) {
@@ -782,7 +785,6 @@
 		}
 
 		if (!page.dungeonActive()) {
-			currentTask.reportDebug();
 			const expectedClears = currentTask.playerClears + (currentTask.started? 1 : 0);
 			const actualClears = page.getDungeonClears(currentTask.dungeonName);
 			if (actualClears == expectedClears) {
@@ -802,6 +804,7 @@
 				// }
 
 				currentTask.report();
+				currentTask.reportDebug();
 				stopTask();
 				return;
 			}
@@ -809,6 +812,7 @@
 			page.enterDungeon();
 			currentTask.logDungeonEnter();
 			currentTask.writePersistant();
+			currentTask.reportDebug();
 
 			scheduleTick(DELAY_ENTER);
 			return;

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -803,6 +803,7 @@
 
 			page.enterDungeon();
 			currentTask.logDungeonEnter();
+			currentTask.writePersistant();
 
 			scheduleTick(DELAY_ENTER);
 			return;

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -583,6 +583,10 @@
 			this.startShinies = page.getShinyCount();
 		}
 
+		reportDebug() {
+			console.log("Clearing", this.dungeonName, this.clearGoal, "times total. Done", this.taskEntries, "/", this.taskClears, "so far.", this.remainingEntries, "left.");
+		}
+
 		static fromData(data) {
 			const task = new DungeonClearTask(data.dungeonName,
 					data.clearGoal, getNavPolicy(data.navPolicy));
@@ -778,6 +782,7 @@
 		}
 
 		if (!page.dungeonActive()) {
+			currentTask.reportDebug();
 			const expectedClears = currentTask.playerClears + (currentTask.started? 1 : 0);
 			const actualClears = page.getDungeonClears(currentTask.dungeonName);
 			if (actualClears == expectedClears) {

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -546,7 +546,7 @@
 				return new EnemyNavigationPolicy();
 
 			default:
-				throw new Error("Unknown navigation policy key: " + key);
+				throw new Error(`Unknown navigation policy key: '${key}'`);
 		}
 	}
 

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -812,7 +812,6 @@
 
 			page.enterDungeon();
 			currentTask.logDungeonEnter();
-			currentTask.writePersistant();
 			currentTask.reportDebug();
 
 			scheduleTick(DELAY_ENTER);

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Pokéclicker - Auto Dungeon Crawler
 // @namespace    http://tampermonkey.net/
-// @version      1.8.7
+// @version      1.8.7+save-scum
 // @description  Completes dungeons automatically.
 // @author       SyfP
 // @match        https://www.pokeclicker.com/
@@ -278,6 +278,10 @@
 	const DELAY_MOVE     = 250;
 	const DELAY_INITIAL  = 500;
 
+	const SSKEY_TASK = "syfscripts--dungeon--task";
+
+	const SAVEID_TASK_START = "dungeon--task-start";
+
 	/**
 	 * Choose a random element from the array.
 	 */
@@ -552,6 +556,8 @@
 			this.allowFail = false;
 			this.stopOnShiny = false;
 
+			// TODO: Check if the saveManager is available, take a savestate and set a flag if so
+
 			this.taskEntries = 0;
 			this.taskClears = 0;
 			this.startShinies = page.getShinyCount();
@@ -571,6 +577,16 @@
 			this.remainingEntries -= 1;
 			this.taskEntries += 1;
 		}
+
+		// TODO: writePersistant() {
+			// TODO: Write progress and settings values to sessionStorage
+		// }
+
+		// TODO: shouldReload()
+			// TODO: Return true if stopOnShiny and not found Shiny
+
+		// TODO: reload()
+			// TODO: loadState or error if savestate flag not set
 
 		shouldStop() {
 			if (this.remainingEntries <= 0) {
@@ -615,6 +631,7 @@
 				untilShiny: () => {
 					this.stopOnShiny = true;
 					console.log("Will stop on catching a new shiny");
+					// TODO: Mention save scumming if a save state was made
 					return options;
 				},
 			};
@@ -695,15 +712,24 @@
 			const actualClears = page.getDungeonClears(currentTask.dungeonName);
 			if (actualClears == expectedClears) {
 				currentTask.logClear();
+				// TODO: currentTask.writePersistant();
 			} else if (!currentTask.allowFail) {
 				console.log("Failed to clear dungeon");
+				// TODO: Move this to a stopTask function
+				// TODO: Also clear the settings in sessionStorage
 				currentTask = null;
 				return;
 			}
 
 			if (currentTask.shouldStop()) {
+				// TODO:
+				// if (currentTask.shouldReload()) {
+				// 	currentTask.reload();
+				// 	return;
+				// }
+
 				currentTask.report();
-				currentTask = null;
+				currentTask = null; // TODO: stopTask
 				return;
 			}
 
@@ -754,6 +780,8 @@
 	function cmdRun(clears=10) {
 		const dungeonName = page.getCurrentDungeonName();
 		currentTask = new DungeonClearTask(dungeonName, clears);
+		// TODO: Move some of this duplication to a startNewTask function
+		// TODO: Write task settings to sessionStorage with writePersistant
 		scheduleTick(DELAY_INITIAL);
 		console.log("Attempting to clear", dungeonName, currentTask.clearGoal, "times");
 		return currentTask.getOptions();
@@ -793,6 +821,7 @@
 	 */
 	function cmdScriptClearDungeon(amount) {
 		const dungeonName = page.getCurrentDungeonName();
+		// TODO: Use startNewTask here too
 		currentTask = new DungeonClearTask(dungeonName, amount);
 		scheduleTick(DELAY_INITIAL);
 	}
@@ -813,5 +842,7 @@
 			busy: cmdBusy,
 			clearDungeon: cmdScriptClearDungeon,
 		};
+
+		// TODO: Restore saved task
 	})();
 })();

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -561,7 +561,7 @@
 	}
 
 	class DungeonClearTask {
-		constructor(dungeonName, clears, navPolicy) {
+		constructor(dungeonName, clears, navPolicy, suppressSaveState=false) {
 			this.dungeonName = dungeonName;
 			this.playerClears = page.getDungeonClears(dungeonName);
 			this.navigationPolicy = navPolicy;
@@ -576,7 +576,7 @@
 			this.allowFail = false;
 			this.stopOnShiny = false;
 
-			if (syfScripts?.saveManager?.saveState) {
+			if (!suppressSaveState && syfScripts?.saveManager?.saveState) {
 				syfScripts.saveManager.saveState(SAVEID_TASK_START);
 				this.haveSaveAtStart = true;
 			} else {
@@ -597,7 +597,7 @@
 
 		static fromData(data) {
 			const task = new DungeonClearTask(data.dungeonName,
-					data.clearGoal, getNavPolicy(data.navPolicy));
+					data.clearGoal, getNavPolicy(data.navPolicy), true);
 
 			task.startShinies = data.startShinies;
 
@@ -607,6 +607,7 @@
 			task.remainingEntries = data.remainingEntries;
 			task.taskEntries = data.taskEntries;
 			task.taskClears = data.taskClears;
+			task.haveSaveAtStart = data.haveSaveAtStart;
 
 			return task;
 		}
@@ -643,6 +644,7 @@
 				remainingEntries: this.remainingEntries,
 				taskEntries: this.taskEntries,
 				taskClears: this.taskClears,
+				haveSaveAtStart: this.haveSaveAtStart,
 			};
 
 			const json = JSON.stringify(data);

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -787,19 +787,22 @@
 
 	function cmdRun(clears=10) {
 		startNewTask(clears, new FastClearNavigationPolicy());
-		console.log("Attempting to clear", dungeonName, currentTask.clearGoal, "times");
+		console.log("Attempting to clear", currentTask.dungeonName,
+				currentTask.clearGoal, "times");
 		return currentTask.getOptions();
 	}
 
 	function cmdItems(clears=10) {
 		startNewTask(clears, new ItemsNavigationPolicy());
-		console.log("Attempting to clear", dungeonName, currentTask.clearGoal, "times. Focusing on items.");
+		console.log("Attempting to clear", currentTask.dungeonName,
+				currentTask.clearGoal, "times. Focusing on items.");
 		return currentTask.getOptions();
 	}
 
 	function cmdEnemy(clears=10) {
 		startNewTask(clears, new EnemyNavigationPolicy());
-		console.log("Attempting to clear", dungeonName, currentTask.clearGoal, "times. Focusing on enemies.");
+		console.log("Attempting to clear", currentTask.dungeonName,
+				currentTask.clearGoal, "times. Focusing on enemies.");
 		return currentTask.getOptions();
 	}
 

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -591,7 +591,6 @@
 		}
 
 		static fromData(data) {
-			console.log(data);
 			const task = new DungeonClearTask(data.dungeonName,
 					data.clearGoal, getNavPolicy(data.navPolicy));
 
@@ -805,14 +804,12 @@
 				// }
 
 				currentTask.report();
-				currentTask.reportDebug();
 				stopTask();
 				return;
 			}
 
 			page.enterDungeon();
 			currentTask.logDungeonEnter();
-			currentTask.reportDebug();
 
 			scheduleTick(DELAY_ENTER);
 			return;

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -599,7 +599,7 @@
 			task.allowFail = data.allowFail;
 			task.stopOnShiny = data.stopOnShiny;
 
-			task.remainingClears = data.remainingClears;
+			task.remainingEntries = data.remainingEntries;
 			task.taskEntries = data.taskEntries;
 			task.taskClears = data.taskClears;
 
@@ -635,7 +635,7 @@
 				allowFail: this.allowFail,
 				stopOnShiny: this.stopOnShiny,
 
-				remainingClears: this.remainingClears,
+				remainingEntries: this.remainingEntries,
 				taskEntries: this.taskEntries,
 				taskClears: this.taskClears,
 			};

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -535,7 +535,7 @@
 	}
 
 	function getNavPolicy(key) {
-		switch (key.navPolicy) {
+		switch (key) {
 			case "clear":
 				return new FastClearNavigationPolicy();
 

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -868,7 +868,9 @@
 		const taskData = JSON.parse(taskJson);
 		currentTask = DungeonClearTask.fromData(taskData);
 
-		console.log("Resuming dungeon task. Cleared", currentTask.dungeonName, currentTask.taskClears, "so far");
+		console.log("Resuming dungeon task. Cleared",
+				currentTask.dungeonName,
+				currentTask.taskClears, "times so far");
 		scheduleTick(DELAY_INITIAL);
 	}
 

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -663,7 +663,7 @@
 				throw new Error("No save to reload");
 			}
 
-			this.remainingEntries = 0;
+			this.remainingEntries = this.clearGoal;
 			this.writePersistant();
 			syfScripts.saveManager.loadState(SAVEID_TASK_START);
 		}

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -27,6 +27,15 @@
 
 	const page = {
 		/**
+		 * Test if the game has loaded.
+		 *
+		 * @return - Truthy if the game has loaded, false otherwise.
+		 */
+		gameLoaded() {
+			return App?.game;
+		},
+
+		/**
 		 * Not required by interfaces.
 		 * Fetch the dungeon which the player is currently at.
 		 *
@@ -273,10 +282,11 @@
 	 * through the page interface defined above.
 	 */
 
-	const DELAY_ENTER    = 200;
-	const DELAY_FIGHTING = 100;
-	const DELAY_MOVE     = 250;
-	const DELAY_INITIAL  = 500;
+	const DELAY_GAME_LOAD = 1000;
+	const DELAY_ENTER     =  200;
+	const DELAY_FIGHTING  =  100;
+	const DELAY_MOVE      =  250;
+	const DELAY_INITIAL   =  500;
 
 	const SSKEY_TASK = "syfscripts--dungeon--task";
 
@@ -901,6 +911,15 @@
 		startNewTask(amount, new FastClearNavigationPolicy());
 	}
 
+	function onGameLoad(callback) {
+		if (!page.gameLoaded()) {
+			setTimeout(onGameLoad, DELAY_GAME_LOAD, callback);
+			return;
+		}
+
+		callback();
+	}
+
 	(function main() {
 		window.dung = {
 			run: cmdRun,
@@ -918,6 +937,6 @@
 			clearDungeon: cmdScriptClearDungeon,
 		};
 
-		restorePersistantTask();
+		onGameLoad(restorePersistantTask);
 	})();
 })();

--- a/dungeon-crawler.js
+++ b/dungeon-crawler.js
@@ -591,6 +591,7 @@
 		}
 
 		static fromData(data) {
+			console.log(data);
 			const task = new DungeonClearTask(data.dungeonName,
 					data.clearGoal, getNavPolicy(data.navPolicy));
 


### PR DESCRIPTION
When using the `.untilShiny()` option in a dungeon task, the script will now save-scum to repeat the clears until a new shiny is found.